### PR TITLE
Enable Docker image building and fix price formatting on confirmation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:2
+
+WORKDIR .
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD [ "python", "app.py" ]

--- a/templates/confirm_price.html
+++ b/templates/confirm_price.html
@@ -3,7 +3,7 @@
     <div class="confirm_price" align="center">
         <form class="form-inline mt-2 mt-md-0"  action="/lockin" method="POST">
             <div class="form-group">
-                <label for="fueltype">The price per litre will be ${{ session['LockinPrice'] }}.</label></br></br>
+                <label for="fueltype">The price per litre will be {{ session['LockinPrice'] }}c.</label></br></br>
                 <button class="btn btn-default" name="submit" value="confirm_price" type="submit" onclick="loader.style.display = 'block'">Confirm the price!</button><br><br>
                 <h3><a href="./?action=refresh">Cancel lock in</a></h3>
             </div>


### PR DESCRIPTION
Instructions for Docker:

- Edit `settings.py` and add your Google Maps API key.
- Run `docker build -t fuellock .` from within the project directory to build a Docker image tagged as 'fuellock'.
- Run `docker run -d -e API_KEY=YOUR_GOOGLE_API_KEY -p 5000:5000 fuellock` to spawn a container based on this image and forward port 5000 to the container.
- Browse to `<IP of Docker host>:5000` in a web browser.