### PR TITLE
Small fix ups to API_REQUESTS

### DIFF
--- a/API_REQUESTS/api/fuellock.py
+++ b/API_REQUESTS/api/fuellock.py
@@ -36,7 +36,9 @@ def listFuellock(deviceSecret, accessToken):
 
 def startLockinSession(deviceSecret, accessToken, locLat, locLong):
 
-    payload = '{"LastStoreUpdateTimestamp":' + str(int(time.time())) + ',"Latitude":"' + locLat + '","Longitude":"' + locLong + '"}'
+    current_time = str(int(time.time()))
+    payload = f'{{"LastStoreUpdateTimestamp":{current_time},"Latitude":"{locLat}","Longitude":"{locLong}"}}'
+
     tssa = generateTssa(BASE_URL + "FuelLock/StartSession", "POST", payload, accessToken)
 
     headers = {'User-Agent':'Apache-HttpClient/UNAVAILABLE (java 1.4)',

--- a/API_REQUESTS/muti_lock_in.py
+++ b/API_REQUESTS/muti_lock_in.py
@@ -77,7 +77,7 @@ if __name__ == '__main__' :
 
         # Start the lock in session. Here you can confirm the price if you want
         # Note: You need to add the price confirmation yourself.
-        fuellock.startLockinSession(myaccount[0], myaccount[1], fuel_location[2], fuel_location[3]))
+        fuellock.startLockinSession(myaccount[0], myaccount[1], fuel_location[2], fuel_location[3])
 
         # Lock in the price
         fuellock.confirmLockin(myaccount[0], myaccount[1], myaccount[2], FUEL_TYPE, litres)


### PR DESCRIPTION
Was trying to use the API Requests scripts and found a few small things
- Use string interpolation to fix up not being able to use floats in concatenation
- Removed extra bracket

(loved the fact that you did split these things out into the API functions, makes my life a lot easier to lock in for multiple accounts)