### PR TITLE
adding .decode('utf-8') to json content

### DIFF
--- a/app.py
+++ b/app.py
@@ -138,7 +138,7 @@ def login():
         response = requests.post(functions.BASE_URL + "account/login", data=payload, headers=headers)
 
         returnHeaders = response.headers
-        returnContent = json.loads(response.text)
+        returnContent = json.loads(response.text.decode('utf-8'))
 
         try:
             # If there was an error logging in, redirect to the index page with the 7Eleven response
@@ -354,7 +354,7 @@ def lockin():
             returnContent = response.content
 
             # Move the response json into an array so we can read it
-            returnContent = json.loads(returnContent)
+            returnContent = json.loads(returnContent.decode('utf-8'))
 
             # If there is a fuel lock already in place we get an error!
             try:
@@ -406,7 +406,7 @@ def lockin():
         response = requests.post(functions.BASE_URL + "FuelLock/Confirm", data=payload, headers=headers)
 
         # Get the response into a json array
-        returnContent = json.loads(response.content)
+        returnContent = json.loads(response.content.decode('utf-8'))
         try:
             # Check if the response was an error message
             if(returnContent['Message']):

--- a/autolocker.py
+++ b/autolocker.py
@@ -113,7 +113,7 @@ def check_fuellock(accessToken, deviceSecret, DEVICE_ID):
 
     # Send the request and get the response into a JSON array
     response = requests.get(functions.BASE_URL + "FuelLock/List", headers=headers)
-    returnContent = json.loads(response.content)
+    returnContent = json.loads(response.content.decode('utf-8'))
 
 
     config = configparser.ConfigParser()
@@ -231,7 +231,7 @@ def start_lockin():
 
                     # Send through the request and get the response
                     response = requests.post(functions.BASE_URL + "FuelLock/Confirm", data=payload, headers=headers)
-                    returnContent = json.loads(response.content)
+                    returnContent = json.loads(response.content.decode('utf-8'))
 
                     try:
                         if(returnContent['Message']):

--- a/functions.py
+++ b/functions.py
@@ -172,7 +172,7 @@ def lockedPrices():
                'X-DeviceSecret':session['deviceSecret']}
                
     response = requests.get(BASE_URL + "FuelLock/List", headers=headers)
-    returnContent = json.loads(response.content)
+    returnContent = json.loads(response.content.decode('utf-8'))
 
     # An error occours if we have never locked in a price before
     try:


### PR DESCRIPTION
Fix the following error in some instances:
TypeError: the JSON object must be str, not 'bytes'