### PR TITLE
Allow locking for users without a balance

### DIFF
--- a/app.py
+++ b/app.py
@@ -388,7 +388,7 @@ def lockin():
                 return redirect(url_for('confirm'))
 
         # Now we want to lock in the maximum litres we can.
-        NumberOfLitres = int(float(session['cardBalance']) / session['LockinPrice'] * 100)
+        NumberOfLitres = int(150)
 
         # Lets start the actual lock in process
         payload = '{"AccountId":"' + session['accountID'] + '","FuelType":"' + session['fuelType'] + '","NumberOfLitres":"' + str(NumberOfLitres) + '"}'


### PR DESCRIPTION
Changes number of litres to 150 (max) rather than a calculation of card balance and cost as card balance is no longer required.

Currently does not lock for users with no balance due to this calculation