### PR TITLE
using standard python base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.7-alpine
+FROM python
 
-RUN apk --update add --no-cache bash tzdata build-base libffi-dev openssl-dev
+RUN apt update && apt install bash tzdata libffi-dev openssl
 
 WORKDIR .
 


### PR DESCRIPTION
Recently the cryptography seems failed to build in apline version of python base image. I have replaced the alpine version of python with the standard (I believe it's Debian based) version of python base image, and all the builds passed.